### PR TITLE
Adding test to check prioroty 0 is allowed

### DIFF
--- a/modules/integration/tests-integration/humantasks/src/test/java/org/wso2/bps/integration/tests/humantasks/HumanTaskCreationTestCase.java
+++ b/modules/integration/tests-integration/humantasks/src/test/java/org/wso2/bps/integration/tests/humantasks/HumanTaskCreationTestCase.java
@@ -407,14 +407,12 @@ public class HumanTaskCreationTestCase extends BPSMasterTest {
         TPriority newPriority3 = new TPriority();
         newPriority3.setTPriority(BigInteger.valueOf(0));
 
-        manager1HumanTaskClientApiClient.setPriority(taskId,newPriority3);
+        manager1HumanTaskClientApiClient.setPriority(taskId, newPriority3);
 
         TTaskAbstract taskAfterPriorityChange3 = manager1HumanTaskClientApiClient.loadTask(taskId);
         newPriority3 = taskAfterPriorityChange3.getPriority();
-        int newPriorityInt3 = newPriority3.getTPriority().intValue();
-        Assert.assertEquals(newPriorityInt3, 0, "The new priority should be 0 after the set priority " +
-                "operation");
-
+        int newPriority3Int = newPriority3.getTPriority().intValue();
+        Assert.assertEquals(newPriority3Int, 0, "The new priority should be 0 after the set priority " + "operation");
     }
 
     @Test(groups = {"wso2.bps.task.operate"}, description = "Stop task test case", priority = 12, singleThreaded = true)

--- a/modules/integration/tests-integration/humantasks/src/test/java/org/wso2/bps/integration/tests/humantasks/HumanTaskCreationTestCase.java
+++ b/modules/integration/tests-integration/humantasks/src/test/java/org/wso2/bps/integration/tests/humantasks/HumanTaskCreationTestCase.java
@@ -35,13 +35,9 @@ import org.wso2.carbon.humantask.stub.mgt.types.HumanTaskPackageDownloadData;
 import org.wso2.carbon.humantask.stub.ui.task.client.api.types.*;
 import org.wso2.carbon.integration.common.admin.client.UserManagementClient;
 import org.wso2.carbon.integration.common.utils.LoginLogoutClient;
-import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
-import org.wso2.carbon.user.mgt.stub.types.carbon.FlaggedName;
 
 import java.math.BigInteger;
 import java.util.*;
-
-import static org.testng.Assert.assertTrue;
 
 /**
  * This test case deals with task creation by calling the task service interface.
@@ -405,6 +401,18 @@ public class HumanTaskCreationTestCase extends BPSMasterTest {
         TPriority prio2 = taskAfterPriorityChange2.getPriority();
         int newPriority2Int = prio2.getTPriority().intValue();
         Assert.assertEquals(newPriority2Int, 10, "The new priority should be 10 after the set priority " +
+                "operation");
+
+        //test priority 0 is allowed
+        TPriority newPriority3 = new TPriority();
+        newPriority3.setTPriority(BigInteger.valueOf(0));
+
+        manager1HumanTaskClientApiClient.setPriority(taskId,newPriority3);
+
+        TTaskAbstract taskAfterPriorityChange3 = manager1HumanTaskClientApiClient.loadTask(taskId);
+        newPriority3 = taskAfterPriorityChange3.getPriority();
+        int newPriorityInt3 = newPriority3.getTPriority().intValue();
+        Assert.assertEquals(newPriorityInt3, 0, "The new priority should be 0 after the set priority " +
                 "operation");
 
     }


### PR DESCRIPTION
Adding test to check priority 0 is allowed in human tasks for issue - https://wso2.org/jira/browse/BPS-515